### PR TITLE
Add initial SS2 portability workflow

### DIFF
--- a/workflows/smartseq2/smartseq2.wdl
+++ b/workflows/smartseq2/smartseq2.wdl
@@ -1,0 +1,193 @@
+task Star {
+  File input_fastq_read1
+  File input_fastq_read2
+  File gtf
+  File star_genome
+
+  command {
+    tar -xvf ${star_genome}
+    STAR  --readFilesIn ${input_fastq_read1} ${input_fastq_read2} \
+      --genomeDir ./star \
+      --runThreadN `nproc` \
+      --quantMode TranscriptomeSAM \
+      --outSAMstrandField intronMotif \
+      --genomeLoad NoSharedMemory \
+      --sjdbGTFfile ${gtf} \
+      --readFilesCommand "zcat" \
+      --twopassMode Basic \
+      --outSAMtype BAM SortedByCoordinate  \
+      --outSAMunmapped Within \
+      --limitBAMsortRAM 30000000000 
+  }
+  output {
+    File junction_table = "SJ.out.tab"
+    File output_bam = "Aligned.sortedByCoord.out.bam"
+    File output_bam_trans="Aligned.toTranscriptome.out.bam"
+  }
+  runtime {
+    docker:"humancellatlas/star:2.5.3a"
+    memory: "40 GB"
+    disks :"local-disk 100 HDD"
+  }
+}
+
+task FeatureCountsUniqueMapping {
+  File aligned_bam
+  File gtf
+  String fc_out
+  
+  command {
+    featureCounts -s 0 -t exon -g gene_id -p -B -C -a ${gtf} -o "${fc_out}.gene.counts.txt" ${aligned_bam}
+    featureCounts -s 0 -t exon -g transcript_id -p -B -C -a ${gtf} -o "${fc_out}.transcripts.counts.txt" ${aligned_bam}
+    featureCounts -s 0 -t exon -g exon_id -p -B -C -a ${gtf} -o "${fc_out}.exon.counts.txt" ${aligned_bam}
+  }
+  runtime {
+    docker:"humancellatlas/star:2.5.3a"
+    memory: "15 GB"
+    disks :"local-disk 50 HDD"
+  }
+  output {
+    File genes="${fc_out}.gene.counts.txt"
+    File exons="${fc_out}.exon.counts.txt"
+    File trans="${fc_out}.transcripts.counts.txt"
+  }
+}
+
+task RsemExpression {
+  File trans_aligned_bam
+  File rsem_genome
+  String rsem_out
+  
+  command {
+    tar -xvf ${rsem_genome}
+    echo "Aligning fastqs and calculating expression"
+    rsem-calculate-expression -p `nproc` --bam --paired-end ${trans_aligned_bam} rsem/rsem_trans_index  "${rsem_out}"
+    ## parse gene expected_count out
+    cut -f 1,4,5 "${rsem_out}.genes.results" >"${rsem_out}.gene.expected_counts"
+  }
+  runtime {
+    docker: "humancellatlas/rsem:v1.3.0"
+    memory: "10 GB"
+    disks: "local-disk 100 HDD"
+  }
+  output {
+    File rsem_gene="${rsem_out}.genes.results"
+    File rsem_transc="${rsem_out}.isoforms.results"
+    File rsem_gene_count="${rsem_out}.gene.expected_counts"
+   }
+}
+
+task CollectAlignmentSummaryMetrics {
+  File aligned_bam
+  File ref_genome_fasta
+  String output_filename
+  
+  command {
+    java -Xmx10g -jar /usr/picard/picard.jar CollectAlignmentSummaryMetrics \
+      VALIDATION_STRINGENCY=SILENT \
+      METRIC_ACCUMULATION_LEVEL=ALL_READS \
+      INPUT=${aligned_bam} \
+      OUTPUT="${output_filename}" \
+      REFERENCE_SEQUENCE=${ref_genome_fasta} \
+      ASSUME_SORTED=true
+  }
+  output {
+    File alignment_metrics ="${output_filename}"
+  }
+  runtime {
+    docker:"humancellatlas/picard:2.10.10"
+    memory:"10 GB"
+    disks: "local-disk 10 HDD"
+  }
+}
+
+task CollectRnaSeqMetrics {
+  File aligned_bam
+  File ref_genome_fasta
+  File rrna_interval
+  String output_filename
+  File ref_flat
+  
+  command {
+    java -Xmx10g -jar /usr/picard/picard.jar  CollectRnaSeqMetrics \
+      VALIDATION_STRINGENCY=SILENT \
+      REF_FLAT=${ref_flat} \
+      RIBOSOMAL_INTERVALS=${rrna_interval} \
+      INPUT=${aligned_bam} \
+      OUTPUT="${output_filename}" \
+      REFERENCE_SEQUENCE=${ref_genome_fasta} \
+      ASSUME_SORTED=true \
+      STRAND_SPECIFICITY=NONE
+  }
+  output {
+    File rna_metrics="${output_filename}"
+  }
+  runtime {
+    docker:"humancellatlas/picard:2.10.10"
+    memory:"10 GB"
+    disks: "local-disk 10 HDD"
+  }
+}
+
+workflow Ss2RsemSingleSample {
+  File fastq_read1
+  File fastq_read2
+  File gtf
+  File ref_fasta
+  File rrna_interval
+  File ref_flat
+  String star_genome
+  String output_prefix
+  String rsem_genome
+  
+  call Star {
+    input:
+      input_fastq_read1 = fastq_read1,
+      input_fastq_read2 = fastq_read2,
+      gtf = gtf,
+      star_genome = star_genome
+  }
+ 
+  call RsemExpression {
+    input:
+      trans_aligned_bam=Star.output_bam_trans,
+      rsem_genome = rsem_genome,
+      rsem_out = output_prefix
+  }
+
+  call FeatureCountsUniqueMapping {
+    input:
+      aligned_bam=Star.output_bam,
+      gtf =gtf,
+      fc_out=output_prefix
+  }
+
+  call CollectRnaSeqMetrics {
+    input:
+      aligned_bam=Star.output_bam,
+      ref_genome_fasta=ref_fasta,
+      rrna_interval = rrna_interval,
+      output_filename = "${output_prefix}_rna_metrics",
+      ref_flat= ref_flat
+  }
+
+  call CollectAlignmentSummaryMetrics {
+    input:
+      aligned_bam = Star.output_bam,
+      ref_genome_fasta = ref_fasta,
+      output_filename ="${output_prefix}_alignment_metrics"
+  }
+
+  output {
+    File bam_file=Star.output_bam
+    File bam_trans=Star.output_bam_trans
+    File rna_metrics=CollectRnaSeqMetrics.rna_metrics
+    File aln_metrics=CollectAlignmentSummaryMetrics.alignment_metrics
+    File rsem_gene_results=RsemExpression.rsem_gene
+    File rsem_isoform_results=RsemExpression.rsem_transc
+    File rsem_gene_count=RsemExpression.rsem_gene_count
+    File gene_unique_counts=FeatureCountsUniqueMapping.genes
+    File exon_unique_counts=FeatureCountsUniqueMapping.exons
+    File transcript_unique_counts=FeatureCountsUniqueMapping.trans
+  }
+}

--- a/workflows/smartseq2/smartseq2_checker.wdl
+++ b/workflows/smartseq2/smartseq2_checker.wdl
@@ -1,0 +1,15 @@
+task SmartSeq2Checker {
+  File aln_metrics
+
+  String expected_aln_metrics_hash
+
+  command <<<
+    aln_metrics_hash=$(tail -n +6 ${aln_metrics} | md5sum | awk '{print $1}')
+    
+    if [ "$aln_metrics_hash" != "$expected_aln_metrics_hash" ]; then
+      exit 1
+    fi
+  >>>
+
+  output {}
+}

--- a/workflows/smartseq2/smartseq2_inputs.json
+++ b/workflows/smartseq2/smartseq2_inputs.json
@@ -1,0 +1,12 @@
+{
+  "Ss2RsemSingleSample.output_prefix": "SRR1294876",  
+  "Ss2RsemSingleSample.fastq_read1": "https://s3.amazonaws.com/mk-hca-portability-data/SRR1294876_10000_1.fastq.gz",
+  "Ss2RsemSingleSample.fastq_read2": "https://s3.amazonaws.com/mk-hca-portability-data/SRR1294876_10000_2.fastq.gz",
+  "Ss2RsemSingleSample.gtf": "https://s3.amazonaws.com/mk-hca-portability-data/gencodev19_chr21.gtf",
+  "Ss2RsemSingleSample.ref_fasta": "https://s3.amazonaws.com/mk-hca-portability-data/chr21.fa",
+  "Ss2RsemSingleSample.ref_flat": "https://s3.amazonaws.com/mk-hca-portability-data/refFlat.chr21.txt",
+  "Ss2RsemSingleSample.rrna_interval": "https://s3.amazonaws.com/mk-hca-portability-data/hg19.chr21.rRNA.interval_list",
+  "Ss2RsemSingleSample.star_genome": "https://s3.amazonaws.com/mk-hca-portability-data/star.tar",
+  "Ss2RsemSingleSample.rsem_genome": "https://s3.amazonaws.com/mk-hca-portability-data/rsem.tar",
+  "Ss2RsemSingleSample.expected_aln_metrics_hash": "abc123"
+}

--- a/workflows/smartseq2/smartseq2_portability.wdl
+++ b/workflows/smartseq2/smartseq2_portability.wdl
@@ -1,0 +1,40 @@
+import "smartseq2.wdl" as target
+import "smartseq2_checker.wdl" as checker
+
+workflow Ss2RsemSingleSample {
+  # Inputs to the target workflow
+  File fastq_read1
+  File fastq_read2
+  File gtf
+  File ref_fasta
+  File rrna_interval
+  File ref_flat
+  String star_genome
+  String output_prefix
+  String rsem_genome
+  
+  # Inputs to the checker tools
+  String expected_aln_metrics_hash
+
+  
+  # Run the target workflow  
+  call target.Ss2RsemSingleSample as ss2 {
+    input:
+      fastq_read1=fastq_read1,
+      fastq_read2=fastq_read2,
+      gtf=gtf,
+      ref_fasta=ref_fasta,
+      rrna_interval=rrna_interval,
+      ref_flat=ref_flat,
+      star_genome=star_genome,
+      output_prefix=output_prefix,
+      rsem_genome=rsem_genome
+  }
+  
+  # Run the tool to check its outputs
+  call checker.SmartSeq2Checker as check {
+    input:
+      aln_metrics=ss2.aln_metrics,
+      expected_aln_metrics_hash=expected_aln_metrics_hash 
+  }
+}


### PR DESCRIPTION
This is an example of a "portability test" workflow. It's small, but it
has all the relevant components:

1. A portability workflow that calls the target workflow as a
subworkflow.
2. A WDL task reponsible for checking the outputs of the target workflow
agains expected values (the "checker tool")
3. Fast-running test inputs