### PR TITLE
Implement WES logging/info endpoint for local cromwell

### DIFF
--- a/external_executors/local_cromwell/README.md
+++ b/external_executors/local_cromwell/README.md
@@ -7,21 +7,24 @@ environment for the HCA's secondary analysis workflows.
 There are two files:
 
 ### local_cromwell.py
-This defines two Lambda functions that are responsible for handling two
-request types: POSTs to `/workflows` and GETs to
-`/workflows/{workflow_id}/status`. These two calls are enough to launch a test
-workflow and see if it worked.
+This defines three Lambda functions that are responsible for handling three
+request types:
+
+- POST `/workflows`
+- GET `/workflows/{workflow_id}/status`
+- GET `/workflows/{workflow_id}`
 
 A POST to `/workflows` is handled by the `workflows_post` function. That
 launches an EC2 instance that will run Cromwell and record outcomes in a
 database. A GET to `/workflows/{workflow_id}/status` is handled by the
 `workflow_status` function. That queries the database for events associated
-with the `workflow_id` and reports its status using WES terms. (NB: The 404
-response doesn't quite work for this yet.)
+with the `workflow_id` and reports its status using WES terms. A GET to
+`/workflows/{workflow_id}` is handled by the `workflow_log` function and
+reports status along with logging information.
 
 ### local_cromwell_template.json
 This is an AWS Cloudformation template for the local Cromwell service. It
-deploys an API to a "test" stage that has the two endpoints mentioned above.
+deploys an API to a "test" stage that has the three endpoints mentioned above.
 The template handles all the AWS concerns like setting up roles, policies,
 tables, functions, etc. The template contains a definition of the API using
 Swagger.
@@ -34,3 +37,42 @@ There are two steps to deploying the service:
    `local_cromwell_template.json`. This can be done through the AWS console.
    You will have to supply the bucket and file name for the
    `local_cromwell.zip` file that you uploaded.
+
+This can be done with the deploy.sh script:
+```
+sh deploy.sh <stack_name> <bucket_name>
+```
+
+## Limitations
+The jobs have a hard-coded 90-minute time limit. There does appear to be a
+corner case where jobs will hang, so this attemps to avoid that.
+
+## Example Output
+
+A GET to `/workflows/{workflow_id}` returns logs for the overall workflow
+produced by Cromwell, as well as task-level logs from the stdout and stderr
+files in their respective execution directories. A simple response would look
+like this:
+
+```
+{
+    "state": "Complete",
+    "task_logs": [
+        {
+            "exit_code": 0,
+            "name":
+"CountLinesWorkflow/7068639b-7225-464f-b1e8-052b49a602b3/call-CountLines/execution",
+            "stderr": "And something in stderr!\n\n\n",
+            "stdout": "Oh hey something in stdout!\n"
+        }
+    ],
+    "workflow_id": "326f1ca3-b3ce-4281-8dc5-028857e72a46",
+    "workflow_log": {
+        "end_time": "2018-03-30T21:36:22Z",
+        "exit_code": "0",
+        "start_time": "2018-03-30T21:35:59Z",
+        "stderr": "",
+        "stdout": "[2018-03-30 21:36:02,25] [info] Running with database db.url = jdbc:hsqldb:mem:053244c2-1a31-4c38-8512-14e63920391d;shutdown=false;hsqldb.tx=mvcc\n[2018-03-30 21:36:07,74] [info] Running migration RenameWorkflowOptionsInMetadata with a read batch size of 100000 and a write batch size of 100000\n[2018-03-30 21:36:07,75] [info] [RenameWorkflowOptionsInMetadata] 100%\n[2018-03-30 21:36:07,87] [info] Running with database db.url = jdbc:hsqldb:mem:f3555b67-8005-444f-b1f5-8a048a254086;shutdown=false;hsqldb.tx=mvcc\n[2018-03-30 21:36:08,33] [info] Slf4jLogger started\n[2018-03-30 21:36:08,64] [info] Metadata summary refreshing every 2 seconds.\n[2018-03-30 21:36:08,66] [info] CallCacheWriteActor configured to write to the database with batch size 100 and flush rate 3 seconds.\n[2018-03-30 21:36:08,67] [info] WriteMetadataActor configured to write to the database with batch size 200 and flush rate 5 seconds.\n[2018-03-30 21:36:08,70] [info] Starting health monitor with the following checks: DockerHub, Engine Database\n[2018-03-30 21:36:09,54] [info] SingleWorkflowRunnerActor: Submitting workflow\n[2018-03-30 21:36:09,60] [info] Workflow 7068639b-7225-464f-b1e8-052b49a602b3 submitted.\n[2018-03-30 21:36:09,60] [info] SingleWorkflowRunnerActor: Workflow submitted \u001b[38;5;2m7068639b-7225-464f-b1e8-052b49a602b3\u001b[0m\n[2018-03-30 21:36:09,60] [info] 1 new workflows fetched\n[2018-03-30 21:36:09,60] [info] WorkflowManagerActor Starting workflow \u001b[38;5;2m7068639b-7225-464f-b1e8-052b49a602b3\u001b[0m\n[2018-03-30 21:36:09,61] [info] WorkflowManagerActor Successfully started WorkflowActor-7068639b-7225-464f-b1e8-052b49a602b3\n[2018-03-30 21:36:09,61] [info] Retrieved 1 workflows from the WorkflowStoreActor\n[2018-03-30 21:36:10,42] [info] MaterializeWorkflowDescriptorActor [\u001b[38;5;2m7068639b\u001b[0m]: Call-to-Backend assignments: CountLinesWorkflow.CountLines -> Local\n[2018-03-30 21:36:12,60] [info] WorkflowExecutionActor-7068639b-7225-464f-b1e8-052b49a602b3 [\u001b[38;5;2m7068639b\u001b[0m]: Starting calls: CountLinesWorkflow.CountLines:NA:1\n[2018-03-30 21:36:12,73] [info] BackgroundConfigAsyncJobExecutionActor [\u001b[38;5;2m7068639b\u001b[0mCountLinesWorkflow.CountLines:NA:1]: \u001b[38;5;5m    echo \"Oh hey something in stdout!\"\n    >&2 echo \"And something in stderr!\n\n\"\n    wc -l /cromwell-executions/CountLinesWorkflow/7068639b-7225-464f-b1e8-052b49a602b3/call-CountLines/inputs/tmp/tmpf8kpw_37/gencode.v27.rRNA.interval_list | awk '{print $1}' > line.count\u001b[0m\n[2018-03-30 21:36:12,75] [info] BackgroundConfigAsyncJobExecutionActor [\u001b[38;5;2m7068639b\u001b[0mCountLinesWorkflow.CountLines:NA:1]: executing: /bin/bash /cromwell-executions/CountLinesWorkflow/7068639b-7225-464f-b1e8-052b49a602b3/call-CountLines/execution/script\n[2018-03-30 21:36:12,79] [info] BackgroundConfigAsyncJobExecutionActor [\u001b[38;5;2m7068639b\u001b[0mCountLinesWorkflow.CountLines:NA:1]: job id: 8840\n[2018-03-30 21:36:12,79] [info] BackgroundConfigAsyncJobExecutionActor [\u001b[38;5;2m7068639b\u001b[0mCountLinesWorkflow.CountLines:NA:1]: Status change from - to WaitingForReturnCodeFile\n[2018-03-30 21:36:16,51] [info] BackgroundConfigAsyncJobExecutionActor [\u001b[38;5;2m7068639b\u001b[0mCountLinesWorkflow.CountLines:NA:1]: Status change from WaitingForReturnCodeFile to Done\n[2018-03-30 21:36:17,60] [info] WorkflowExecutionActor-7068639b-7225-464f-b1e8-052b49a602b3 [\u001b[38;5;2m7068639b\u001b[0m]: Workflow CountLinesWorkflow complete. Final Outputs:\n{\n  \"CountLinesWorkflow.line_count\": 744\n}\n[2018-03-30 21:36:17,63] [info] WorkflowManagerActor WorkflowActor-7068639b-7225-464f-b1e8-052b49a602b3 is in a terminal state: WorkflowSucceededState\n[2018-03-30 21:36:21,51] [info] SingleWorkflowRunnerActor workflow finished with status 'Succeeded'.\n{\n  \"outputs\": {\n    \"CountLinesWorkflow.line_count\": 744\n  },\n  \"id\": \"7068639b-7225-464f-b1e8-052b49a602b3\"\n}\n[2018-03-30 21:36:21,57] [info] Message [cromwell.core.actor.StreamActorHelper$StreamFailed] without sender to Actor[akka://cromwell-system/deadLetters] was not delivered. [1] dead letters encountered. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.\n[2018-03-30 21:36:21,57] [info] Message [cromwell.core.actor.StreamActorHelper$StreamFailed] without sender to Actor[akka://cromwell-system/deadLetters] was not delivered. [2] dead letters encountered. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.\n"
+    }
+}
+```

--- a/external_executors/local_cromwell/deploy.sh
+++ b/external_executors/local_cromwell/deploy.sh
@@ -1,0 +1,11 @@
+rm -f local_cromwell.zip
+zip local_cromwell.zip local_cromwell.py
+aws s3 cp local_cromwell.zip s3://"$2"/local_cromwell.zip
+
+aws cloudformation create-stack --stack-name "$1" \
+    --template-body file://local_cromwell_template.json \
+    --parameters ParameterKey=LambdaCodeBucket,ParameterValue="$2" \
+                 ParameterKey=LambdaCodeKey,ParameterValue=local_cromwell.zip \
+                 ParameterKey=InstanceType,ParameterValue=r4.xlarge \
+                 ParameterKey=VolumeSize,ParameterValue=71 \
+    --capabilities CAPABILITY_NAMED_IAM

--- a/external_executors/local_cromwell/local_cromwell.py
+++ b/external_executors/local_cromwell/local_cromwell.py
@@ -35,7 +35,9 @@ CLOUDFORMATION_VARIABLES = {
     "instance_type": os.environ["INSTANCE_TYPE"],
     "volume_size": int(os.environ["VOLUME_SIZE"]),
     "table_name": os.environ["DB_TABLE"],
-    "iam_profile": os.environ["IAM_PROFILE"]
+    "iam_profile": os.environ["IAM_PROFILE"],
+    "subnet": os.environ["SUBNET"]
+
 }
 
 # This script is responsible for running downloading inputs, running Cromwell,
@@ -325,6 +327,14 @@ def workflows_post(event, context):
         MaxCount=1,
         InstanceInitiatedShutdownBehavior='terminate',
         UserData=user_data,
+        SubnetId=CLOUDFORMATION_VARIABLES["subnet"],
+        TagSpecifications=[{
+            "ResourceType": "instance",
+            "Tags": [
+                {"Key": "Name", "Value": "local-cromwell-portability-test"},
+                {"Key": "JobId", "Value": job_id}
+            ]}
+        ],
         IamInstanceProfile={
             "Arn": CLOUDFORMATION_VARIABLES["iam_profile"]
         }

--- a/external_executors/local_cromwell/local_cromwell.py
+++ b/external_executors/local_cromwell/local_cromwell.py
@@ -73,6 +73,7 @@ END
 function fail {{
     set +e
     record_event "Failed"
+    shutdown -c || true
     shutdown -H 5
 }}
 
@@ -191,6 +192,7 @@ fi
 
 # Turn off the trap or it records Failed twice.
 trap - EXIT
+shutdown -c || true
 shutdown -H 5
 """
 
@@ -217,6 +219,9 @@ script = response["Items"][0]["Message"]
 with open("local_cromwell_run.bash", "w") as f:
     f.write(script)
 END
+
+# Set a maximum run time of 90 minutes to kill stalled jobs.
+shutdown -H 90 &
 
 bash local_cromwell_run.bash
 """

--- a/external_executors/local_cromwell/local_cromwell_template.json
+++ b/external_executors/local_cromwell/local_cromwell_template.json
@@ -25,6 +25,57 @@
         }
     },
     "Resources": {
+        "VPC": {
+            "Type": "AWS::EC2::VPC",
+            "Properties": {
+                "CidrBlock": "172.31.0.0/16",
+                "Tags": [
+                    {"Key": "Name",
+                     "Value": {"Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "vpc"]]}
+                    }
+                ]
+            }
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "IGAttachment": {
+            "Type": "AWS::EC2::VPCGatewayAttachment",
+            "Properties": {
+                "InternetGatewayId": {"Ref": "InternetGateway"},
+                "VpcId": {"Ref": "VPC"}
+            }
+        },
+        "Subnet": {
+            "Type": "AWS::EC2::Subnet",
+            "Properties": {
+                "VpcId": {"Ref": "VPC"},
+                "MapPublicIpOnLaunch": true,
+                "CidrBlock": "172.31.0.0/20"
+            }
+        },
+        "PublicRouteTable": {
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {"Ref": "VPC"}
+            }
+        },
+        "PublicRoute": {
+            "Type": "AWS::EC2::Route",
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {"Ref": "InternetGateway"},
+                "RouteTableId": {"Ref": "PublicRouteTable"}
+            },
+            "DependsOn": "InternetGateway"
+        },
+        "PublicRouteTableSubnetAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "RouteTableId": {"Ref": "PublicRouteTable"},
+                "SubnetId": {"Ref": "Subnet"}
+            }
+        },
         "EventTable": {
             "Type": "AWS::DynamoDB::Table",
             "Properties": {
@@ -144,7 +195,8 @@
                         {
                             "Effect": "Allow",
                             "Action": [
-                                "ec2:RunInstances"
+                                "ec2:RunInstances",
+                                "ec2:CreateTags"
                             ],
                             "Resource": "*"
                         },
@@ -179,7 +231,8 @@
                         "DB_TABLE": {"Ref": "EventTable"},
                         "REGION": {"Ref": "AWS::Region"},
                         "INSTANCE_TYPE": {"Ref": "InstanceType"},
-                        "VOLUME_SIZE": {"Ref": "VolumeSize"}
+                        "VOLUME_SIZE": {"Ref": "VolumeSize"},
+                        "SUBNET": {"Ref": "Subnet"}
                     }
                 },
                 "FunctionName": {"Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "workflows-post-lambda-fn"]]},
@@ -203,7 +256,8 @@
                         "DB_TABLE": {"Ref": "EventTable"},
                         "REGION": {"Ref": "AWS::Region"},
                         "INSTANCE_TYPE": {"Ref": "InstanceType"},
-                        "VOLUME_SIZE": {"Ref": "VolumeSize"}
+                        "VOLUME_SIZE": {"Ref": "VolumeSize"},
+                        "SUBNET": {"Ref": "Subnet"}
                     }
                 },
                 "FunctionName": {"Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "workflows-status-lambda-fn"]]},

--- a/external_executors/local_cromwell/local_cromwell_template.json
+++ b/external_executors/local_cromwell/local_cromwell_template.json
@@ -495,6 +495,34 @@
                 "RestApiId": {"Ref": "CromwellApi"},
                 "StageName": "test"
             }
+        },
+        "ApiTestKey": {
+            "Type": "AWS::ApiGateway::ApiKey",
+            "Properties": {
+                "Name": {"Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "api-key"]]},
+                "Enabled": true
+            }
+        },
+        "ApiUsagePlan": {
+            "Type": "AWS::ApiGateway::UsagePlan",
+            "Properties": {
+                "ApiStages": [
+                    {
+                        "ApiId": {"Ref": "CromwellApi"},
+                        "Stage": "test"
+                    }
+                ],
+                "UsagePlanName": {"Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "usage-plan"]]}
+            },
+            "DependsOn": "ApiTestDeployment"
+        },
+        "ApiUsagePlanKey": {
+            "Type": "AWS::ApiGateway::UsagePlanKey",
+            "Properties": {
+                "KeyId": {"Ref": "ApiTestKey"},
+                "KeyType": "API_KEY",
+                "UsagePlanId": {"Ref": "ApiUsagePlan"}
+            }
         }
     }
 }

--- a/external_executors/local_cromwell/local_cromwell_template.json
+++ b/external_executors/local_cromwell/local_cromwell_template.json
@@ -267,10 +267,35 @@
                 "Timeout": 10
             }
         },
+        "WorkflowLogFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Description": "Handles GET to /workflows/{workflow_id}",
+                "Code": {
+                    "S3Bucket": {"Ref": "LambdaCodeBucket"},
+                    "S3Key": {"Ref": "LambdaCodeKey"}
+                },
+                "Environment": {
+                    "Variables": {
+                        "IAM_PROFILE": {"Fn::GetAtt": ["EC2CromwellProfile", "Arn"]},
+                        "DB_TABLE": {"Ref": "EventTable"},
+                        "REGION": {"Ref": "AWS::Region"},
+                        "INSTANCE_TYPE": {"Ref": "InstanceType"},
+                        "VOLUME_SIZE": {"Ref": "VolumeSize"},
+                        "SUBNET": {"Ref": "Subnet"}
+                    }
+                },
+                "FunctionName": {"Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "workflows-log-lambda-fn"]]},
+                "Handler": "local_cromwell.workflow_log",
+                "Role": {"Fn::GetAtt": ["LambdaRole", "Arn"]},
+                "Runtime": "python3.6",
+                "Timeout": 10
+            }
+        },
         "CromwellApi": {
             "Type": "AWS::ApiGateway::RestApi",
             "Properties": {
-                "Name": {"Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "cromwell-api"]]},
+                "Name": {"Fn::Join": ["-", [{"Ref": "AWS::StackName"}, "api"]]},
                 "Description": "WES-esque API for a service that runs WDLs with a local cromwell backend.",
                 "Body": {
                     "swagger": "2.0",
@@ -306,7 +331,16 @@
                                 }
                             }
                         },
-                        "workflowrequest": {
+                        "WESWorkflowRunId": {
+                            "type": "object",
+                            "properties": {
+                                "workflow_id": {
+                                    "type": "string",
+                                    "title": "workflow ID"
+                                }
+                            }
+                        },
+                        "WESWorkflowRequest": {
                             "type": "object",
                             "properties": {
                                 "workflow_descriptor": {
@@ -321,7 +355,63 @@
                             },
                             "title": "workflow request"
                         },
-                        "workflowstatus": {
+                        "WESState": {
+                            "type": "string",
+                            "enum": [
+                                "UNKNOWN",
+                                "QUEUED",
+                                "INITIALIZING",
+                                "RUNNING",
+                                "PAUSED",
+                                "COMPLETE",
+                                "EXECUTOR_ERROR",
+                                "SYSTEM_ERROR",
+                                "CANCELED"
+                            ],
+                            "default": "UNKNOWN",
+                            "title": "Enumeration of WES states"
+                        },
+                        "WESWorkflowDesc": {
+                            "type": "object",
+                            "properties": {
+                                "workflow_id": {
+                                    "type": "string",
+                                    "title": "REQUIRED"
+                                },
+                                "state": {
+                                    "$ref": "#/definitions/WESState"
+                                }
+                            }
+                        },
+                        "WESLog": {
+                            "type": "object",
+                            "properties": {
+                                "workflow_id": {
+                                    "type": "string",
+                                    "title": "workflow ID"
+                                },
+                                "stdout": {
+                                    "type": "string",
+                                    "title": "stdout"
+                                },
+                                "stderr": {
+                                    "type": "string",
+                                    "title": "stderr"
+                                },
+                                "start_time": {
+                                    "type": "string"
+                                },
+                                "end_time": {
+                                    "type": "string"
+                                },
+                                "exit_code": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "title": "Exit code"
+                                }
+                            }
+                        },
+                        "WESWorkflowLog": {
                             "type": "object",
                             "properties": {
                                 "workflow_id": {
@@ -329,18 +419,28 @@
                                     "title": "workflow ID"
                                 },
                                 "state": {
+                                    "$ref": "#/definitions/WESState"
+                                },
+                                "workflow_log": {
+                                    "$ref": "#/definitions/WESLog"
+                                },
+                                "task_logs": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/WESLog"
+                                    }
+                                }
+                            }
+                        },
+                        "WESWorkflowStatus": {
+                            "type": "object",
+                            "properties": {
+                                "workflow_id": {
                                     "type": "string",
-                                    "enum": [
-                                        "Unknown",
-                                        "Queued",
-                                        "Running",
-                                        "Paused",
-                                        "Complete",
-                                        "Error",
-                                        "SystemError",
-                                        "Canceled",
-                                        "Initializing"
-                                    ]
+                                    "title": "workflow ID"
+                                },
+                                "state": {
+                                    "$ref": "#/definitions/WESState"
                                 }
                             }
                         }
@@ -356,19 +456,14 @@
                                     "in": "body",
                                     "required": true,
                                     "schema": {
-                                        "$ref": "#/definitions/workflowrequest"
+                                        "$ref": "#/definitions/WESWorkflowRequest"
                                     }
                                 }],
                                 "responses": {
                                     "200": {
                                         "description": "Job created",
                                         "schema": {
-                                            "type": "object",
-                                            "properties": {
-                                                "workflow_id": {
-                                                    "type": "string"
-                                                }
-                                            }
+                                            "$ref": "#/definitions/WESWorkflowRunId"
                                         }
                                     }
                                 },
@@ -395,6 +490,62 @@
                                 }
                             }
                         },
+                        "/workflows/{workflow_id}": {
+                            "get": {
+                                "security": [{
+                                    "api_key": []
+                                }],
+                                "parameters": [{
+                                    "name": "workflow_id",
+                                    "in": "path",
+                                    "required": true,
+                                    "type": "string"
+                                }],
+                                "responses": {
+                                    "200": {
+                                        "schema": {
+                                            "$ref": "#/defintions/WESWorkflowLog"
+                                        }
+                                    },
+                                    "404": {
+                                        "description": "Workflow not found",
+                                        "schema": {
+                                            "$ref": "#/definitions/error"
+                                        }
+                                    }
+                                },
+                                "x-amazon-apigateway-integration": {
+                                    "type": "aws",
+                                    "uri": {"Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:aws:apigateway:",
+                                            {"Ref": "AWS::Region"},
+                                            ":lambda:path",
+                                            "/2015-03-31/functions/",
+                                            {"Fn::GetAtt": ["WorkflowLogFunction", "Arn"]},
+                                            "/invocations"
+                                        ]
+                                    ]},
+                                    "requestTemplates": {
+                                        "application/json": "{\"workflow_id\": \"$input.params('workflow_id')\"}"
+                                    },
+                                    "httpMethod": "POST",
+                                    "passthroughBehavior": "when_no_match",
+                                    "responses": {
+                                        "default": {
+                                            "statusCode": "200"
+                                        },
+                                        ".*httpStatus.*404.*": {
+                                            "statusCode": "404",
+                                            "responseTemplates": {
+                                                "application/json": "#set ($errorMessageObj = $util.parseJson($input.path('$.errorMessage')))\n#set ($bodyObj = $util.parseJson($input.body))\n{\n  \"type\" : \"$errorMessageObj.errorType\",\n  \"message\" : \"$errorMessageObj.message\",\n  \"request-id\" : \"$errorMessageObj.requestId\"\n}"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
                         "/workflows/{workflow_id}/status": {
                             "get": {
                                 "security": [{
@@ -409,7 +560,7 @@
                                 "responses": {
                                     "200": {
                                         "schema": {
-                                            "$ref": "#/defintions/workflowstatus"
+                                            "$ref": "#/defintions/WESWorkflowStatus"
                                         }
                                     },
                                     "404": {
@@ -486,6 +637,23 @@
                     ":",
                     {"Ref": "CromwellApi"},
                     "/*/GET/workflows/*/status"
+                ]]}
+            }
+        },
+        "LambdaWorkflowLogPermission": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+                "Action": "lambda:InvokeFunction",
+                "FunctionName": {"Fn::GetAtt": ["WorkflowLogFunction", "Arn"]},
+                "Principal": "apigateway.amazonaws.com",
+                "SourceArn": {"Fn::Join": ["", [
+                    "arn:aws:execute-api:",
+                    {"Ref": "AWS::Region"},
+                    ":",
+                    {"Ref": "AWS::AccountId"},
+                    ":",
+                    {"Ref": "CromwellApi"},
+                    "/*/GET/workflows/*"
                 ]]}
             }
         },


### PR DESCRIPTION
Previously, there wasn't a way to get log information from runs in the local cromwell environment. This PR implements (most of) the `workflows/{workflow_id}` WES endpoint, which returns logs for both the overall workflow and each task.

This also moves the EC2 instances into their own VPC to improve isolation and make it easier to monitor.